### PR TITLE
[arch-full] install openmpi

### DIFF
--- a/arch/full/Dockerfile.in
+++ b/arch/full/Dockerfile.in
@@ -12,7 +12,7 @@ FROM dunecommunity/arch-minimal
 ENV DXT_ENVIRONMENT arch-full
 
 RUN ${PACMAN_UPDATE} && \
-    ${PACMAN_INSTALL} alberta-wo-fem eigen lapacke intel-tbb
+    ${PACMAN_INSTALL} alberta-wo-fem eigen lapacke intel-tbb openmpi
 
 include(labels)
 


### PR DESCRIPTION
Is there (still?) a reason not to install MPI in the full image?