### PR TITLE
[arch] pin to a given tag

### DIFF
--- a/arch/minimal/Dockerfile.in
+++ b/arch/minimal/Dockerfile.in
@@ -7,7 +7,7 @@
 #   Felix Schindler (2017)
 #   Rene Milk       (2017)
 
-FROM base/devel
+FROM base/devel:2018.04.01
 
 ENV PACMAN_INSTALL="pacman -S --noconfirm " \
     PACMAN_UPDATE="pacman -Syuu --noconfirm " \


### PR DESCRIPTION
I'm running into weird issues in arch and I want to make sure that the underlying system is not the issue when changing between builds. 
I would prefer to only occasionally increment the base image tag. What say you @dune-community/dockerfiles-devs ?