### PR TITLE
[debian] install gitk and git-gui in interactive

### DIFF
--- a/debian/include/interactive
+++ b/debian/include/interactive
@@ -23,7 +23,7 @@ RUN APT_UPDATE APT_REDIRECT && \
     APT_INSTALL bash-completion ccache libc++1 libclang-${CLANG_VERSION}-dev \
         llvm-${CLANG_VERSION} clang-${CLANG_VERSION} \
         clang-format-${CLANG_VERSION} gdb ninja-build libstdc++6-${GCC_VERSION}-dbg\
-        ack git git-gui gitk time valgrind vim-nox wget build-essential cmake \
+        ack git time valgrind vim-nox wget build-essential cmake \
         less libnotify-bin openssh-server ruby ruby-dev APT_REDIRECT && \
     update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-${CLANG_VERSION} 100 && \
     update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${CLANG_VERSION} 100 && \

--- a/debian/include/interactive
+++ b/debian/include/interactive
@@ -23,7 +23,7 @@ RUN APT_UPDATE APT_REDIRECT && \
     APT_INSTALL bash-completion ccache libc++1 libclang-${CLANG_VERSION}-dev \
         llvm-${CLANG_VERSION} clang-${CLANG_VERSION} \
         clang-format-${CLANG_VERSION} gdb ninja-build libstdc++6-${GCC_VERSION}-dbg\
-        ack git time valgrind vim-nox wget build-essential cmake \
+        ack git git-gui gitk time valgrind vim-nox wget build-essential cmake \
         less libnotify-bin openssh-server ruby ruby-dev APT_REDIRECT && \
     update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-${CLANG_VERSION} 100 && \
     update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${CLANG_VERSION} 100 && \

--- a/debian/include/qtcreator
+++ b/debian/include/qtcreator
@@ -1,6 +1,6 @@
 RUN APT_UPDATE && \
     apt-get dist-upgrade -qqy --no-install-recommends APT_REDIRECT && \
-    APT_INSTALL aptitude && \
+    APT_INSTALL git-gui gitk && \
     wget -q http://de.archive.ubuntu.com/ubuntu/pool/main/u/ubuntu-font-family-sources/ttf-ubuntu-font-family_0.80-0ubuntu2_all.deb && \
     dpkg -i ttf-ubuntu-font-family_0.80-0ubuntu2_all.deb APT_REDIRECT && \
     rm ttf-ubuntu-font-family_0.80-0ubuntu2_all.deb 


### PR DESCRIPTION
Since I do not have clang-6 available atm, I would like to be able to used my usual tools when committing from within the docker.