### PR TITLE
[debian] add clang-format-6.0 to stretch minimal

### DIFF
--- a/debian/include/stretch-minimal
+++ b/debian/include/stretch-minimal
@@ -30,7 +30,7 @@ RUN APT_UPDATE APT_REDIRECT && \
                 libboost-timer-dev libboost-chrono-dev libsuperlu-dev libtool \
                 pkg-config python3 python3-dbg python3-dev libgraphviz-dev python3-tk \
                 python3-pip python3-virtualenv unzip virtualenv wget libopenblas-dev \
-                g++-${GCC_VERSION} gcc-${GCC_VERSION} gfortran-${GCC_VERSION} \
+                g++-${GCC_VERSION} gcc-${GCC_VERSION} gfortran-${GCC_VERSION} clang-format-6.0 \
                 ca-certificates wget sudo cmake cmake-curses-gui gosu APT_REDIRECT && \
     apt-get autoremove -y APT_REDIRECT && \
     apt-get clean && \


### PR DESCRIPTION
This is what we need for our current specs, and currently not installed. Or am I missing something, @renefritze?