### PR TITLE
bump debian version

### DIFF
--- a/rules.mk
+++ b/rules.mk
@@ -29,7 +29,7 @@ $(REPONAMES): check_client
 		-D IMAGE="$(IMAGE)" \
 		-D AUTHOR="$(AUTHOR)" \
 		-D GITREV=$(GITREV) \
-		-D DEBIANBASEDATE=20200224 \
+		-D DEBIANBASEDATE=20200607 \
 		-D DEBIANVERSION=$(DEBIANVERSION) \
 		-I$(THISDIR)/include -I ./include $@/Dockerfile.in > $@/$(DF)
 	(test -n "${DOCKER_PRUNE}" && docker system prune -f) || true


### PR DESCRIPTION
This gets you beyond the initial apt setup @ftalbrecht 

No idea how debian broke the previous base image. I use dated tags for a reason...