### PR TITLE
[debian.include.minimal] do not set ASAN_SYMBOLIZER_PATH and ASAN_OPTIONS

### DIFF
--- a/debian/include/minimal
+++ b/debian/include/minimal
@@ -3,10 +3,7 @@ ifelse(DEBIANVERSION, `buster', include(buster-minimal), include(unstable-minima
 ifelse(DEBIANVERSION, `buster', `define(`LIBCPP_DEV', `libc++-dev')', `define(`LIBCPP_DEV', `libc++-dev')')
 ifelse(DEBIANVERSION, `buster', `define(`JDK', `openjdk-11-jdk')', `define(`JDK', `openjdk-11-jdk')')
 
-# ASAN docs: https://github.com/google/sanitizers/wiki/AddressSanitizerFlags
 ENV DEBIAN_FRONTEND=noninteractive \
     DXT_LIBCLANG_SO=/usr/lib/llvm-${CLANG_VERSION}/lib/libclang.so.1 \
-    ASAN_SYMBOLIZER_PATH=/usr/bin/asan_symbolize-${CLANG_VERSION} \
-    ASAN_OPTIONS=check_initialization_order=1:detect_leaks=0:abort_on_error=1 \
     CCACHE_COMPILERCHECK=content \
     CCACHE_COMPRESS=true


### PR DESCRIPTION
ASAN_SYMBOLIZER_PATH was set to the wrong symbolizer, and asan should work
fine without explicitly setting the path (as long as llvm-symbolizer is
available in PATH). ASAN_OPTIONS are currently provided in the config.opts
module, no need to set them (possibly to a different value) here.