### PR TITLE
bump clang version in unstable

### DIFF
--- a/debian/include/unstable-minimal
+++ b/debian/include/unstable-minimal
@@ -4,8 +4,8 @@ FROM debian:unstable-DEBIANBASEDATE
 
 ENV DEBIAN_FRONTEND=noninteractive \
     DXT_ENVIRONMENT=debian-minimal \
-    CLANG_VERSION=10 \
-    CLANG_PYTHON_VERSION=10 \
+    CLANG_VERSION=11 \
+    CLANG_PYTHON_VERSION=11 \
     CLANG_PYTHON_PACKAGE=python3-clang \
     GCC_VERSION=10 \
     DXT_DOCKER=1 \


### PR DESCRIPTION
Debian unstable bumped clang to 11 making
10 no longer available to us there.
Shouldn't be a problem since clang-format binary
is installed separately.
